### PR TITLE
fix bubble position

### DIFF
--- a/Philidea.Website/Pages/acgc-se/acgc-se_layout.cshtml
+++ b/Philidea.Website/Pages/acgc-se/acgc-se_layout.cshtml
@@ -50,6 +50,35 @@
 
     <!--BODY-->
     <div class="container" style="margin:20px;">
+
+        <!-- TOOLTIP BUBBLE FOR INVENTORY -->
+        <div class="ac-bubble">
+            <div class="ac-bubble-tooltip">
+                <div class="ac-bubble-triangle">
+                    <img src="acgc-se/ui-icons/bubble-triangle.png">
+                </div>
+                <div class="ac-bubble-container">
+                    <div class="ac-bubble-tl">
+                        <img src="acgc-se/ui-icons/bubble-corner.png">
+                    </div>
+                    <div class="ac-bubble-tr">
+                        <img src="acgc-se/ui-icons/bubble-corner.png">
+                    </div>
+                    <div class="ac-bubble-mc">
+                        <div class="ac-bubble-content">
+                            <p>Present (Buried Pitfall (Bent & Angled Down-Left Slightly))</p>
+                        </div>
+                    </div>
+                    <div class="ac-bubble-bl">
+                        <img src="acgc-se/ui-icons/bubble-corner.png">
+                    </div>
+                    <div class="ac-bubble-br">
+                        <img src="acgc-se/ui-icons/bubble-corner.png">
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <main role="main" class="pb-3">
             @RenderBody()
         </main>

--- a/Philidea.Website/Pages/acgc-se/player.cshtml
+++ b/Philidea.Website/Pages/acgc-se/player.cshtml
@@ -163,31 +163,3 @@
         </div>
     </div>
 </div>
-
-<!-- TOOLTIP BUBBLE FOR INVENTORY -->
-<div class="ac-bubble">
-    <div class="ac-bubble-tooltip">
-        <div class="ac-bubble-triangle">
-            <img src="acgc-se/ui-icons/bubble-triangle.png">
-        </div>
-        <div class="ac-bubble-container">
-            <div class="ac-bubble-tl">
-                <img src="acgc-se/ui-icons/bubble-corner.png">
-            </div>
-            <div class="ac-bubble-tr">
-                <img src="acgc-se/ui-icons/bubble-corner.png">
-            </div>
-            <div class="ac-bubble-mc">
-                <div class="ac-bubble-content">
-                    <p>Present (Buried Pitfall (Bent & Angled Down-Left Slightly))</p>
-                </div>
-            </div>
-            <div class="ac-bubble-bl">
-                <img src="acgc-se/ui-icons/bubble-corner.png">
-            </div>
-            <div class="ac-bubble-br">
-                <img src="acgc-se/ui-icons/bubble-corner.png">
-            </div>
-        </div>
-    </div>
-</div>


### PR DESCRIPTION
Just needed to be moved back to the proper parent level. I think the positioning method of the children was creating a Y offset but that's just a hypothesis. It's fixed now regardless.

![bubble](https://github.com/phil-macrocheira/Philidea/assets/5730541/a1ae2824-2538-4dfc-8394-255e516da66e)
